### PR TITLE
Prevent runnow while nightly running

### DIFF
--- a/server.py
+++ b/server.py
@@ -113,6 +113,14 @@ def runnow():
     branch = bottle.request.forms.get('branch')
     runner = nightlies.NightlyRunner(CONF_FILE)
     runner.load()
+    runner.load_pid()
+    if runner.data and "pid" in runner.data:
+        try:
+            os.kill(runner.data["pid"], 0)
+        except OSError:
+            pass
+        else:
+            raise bottle.HTTPError(409, "Nightly already running")
     for section in runner.config.sections():
         if repo == section or section.endswith("/" + repo):
             runner.config[section]["branches"] = branch


### PR DESCRIPTION
## Summary
- check if a nightly run is already in progress in `/runnow`
- raise 409 Conflict when a run is already running

## Testing
- `python3 -m py_compile server.py nightlies.py slack.py apt.py cmdline.py status.py`

------
https://chatgpt.com/codex/tasks/task_e_6841fe1469cc83319f8e9b1c17d472f2