### PR TITLE
Add TERM=dumb to systemd-run

### DIFF
--- a/nightlies.py
+++ b/nightlies.py
@@ -72,6 +72,7 @@ SYSTEMD_RUN_CMD = [
     f"--slice={SYSTEMD_SLICE}", # Run with the nightly resource limits
     "--property=Delegate=yes", # Spawned Docker instances inherit resource limits
     "--service-type=simple", # It just execs a program
+    "--setenv=TERM=dumb", # Disable color codes in logs
 ]
 
 REPO_BADGES = [


### PR DESCRIPTION
## Summary
- disable colour in nightly logs by setting `TERM=dumb`

## Testing
- `mypy`

------
https://chatgpt.com/codex/tasks/task_e_68783d5968a88331bef7e90133ad2a0e