### PR TITLE
Warn instead of rerunning on apt updates

### DIFF
--- a/apt.py
+++ b/apt.py
@@ -1,6 +1,5 @@
 from typing import List, TYPE_CHECKING
 import re
-import slack
 
 if TYPE_CHECKING:
     import nightlies
@@ -22,7 +21,4 @@ def check_updates(runner : "nightlies.NightlyRunner", pkgs : List[str]) -> bool:
 def install(runner : "nightlies.NightlyRunner", pkgs : List[str]) -> None:
     runner.log(1, f"Installing apt packages {' '.join(pkgs)}")
     runner.exec(2, ["sudo", "apt", "install", "--yes"] + pkgs)
-
-def post(res : slack.Response) -> None:
-    res.add(slack.TextBlock("`apt`: Reran all branches because a package updated"))
 


### PR DESCRIPTION
## Summary
- Avoid rerunning all branches when apt packages change
- Emit a warning if apt packages update

## Testing
- `python -m mypy`


------
https://chatgpt.com/codex/tasks/task_e_68afb159a3488331a497acf9421b8893