### PR TITLE
Handle empty pid files without crashing server

### DIFF
--- a/nightlies.py
+++ b/nightlies.py
@@ -200,6 +200,8 @@ class NightlyRunner:
             self.start = datetime.fromisoformat(cast(str, self.data["start"]))
         except OSError:
             return
+        except json.decoder.JSONDecodeError:
+            self.data = {"dead": True}
 
     def try_lock(self) -> bool:
         try:

--- a/views/header.view
+++ b/views/header.view
@@ -15,6 +15,7 @@
 %end
 
 %if current:
+  %if "pid" in current and "start" in current and "log" in current:
   <div>
     <form action="{{baseurl}}/logs/{{Path(current['log']).name}}" method="get" class="inline">
       <button>View log</button>
@@ -50,6 +51,7 @@
     (last print {{format_time(last_print)}} ago)
     %end
   </div>
+  %end
   %end
   %if not running:
   <div>


### PR DESCRIPTION
This PR makes the server robust to empty or invalid JSON in the `running.pid` file. This happened today when the disk ran out of space. Mark the run as dead in this case, and make sure the nightly shows the control to delete the PID file 

https://chatgpt.com/codex/tasks/task_e_68bceef02d708331957aa841f3b575f5