### PR TITLE
Cleanup original report directory after publishing

### DIFF
--- a/nightlies.py
+++ b/nightlies.py
@@ -647,6 +647,7 @@ class Branch:
                             self.repo.runner.log(2, f"Linking image file {self.image_file}")
                             path = self.image_file.relative_to(self.report_dir)
                             self.info["img"] = url_base + "/" + str(path)
+                        shutil.rmtree(self.report_dir, ignore_errors=True)
                     elif dest_dir.exists():
                         self.repo.runner.log(2, f"Destination directory {dest_dir} already exists, skipping")
                     else:


### PR DESCRIPTION
## Summary
- remove source report directory after publishing it to the central reports area

## Testing
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_68bf62d600788331ad5b0a73e2a1432e