### PR TITLE
Refactor out Slack interaction

### DIFF
--- a/nightlies.py
+++ b/nightlies.py
@@ -146,7 +146,6 @@ class NightlyRunner:
         self.log_dir = Path(defaults.get("logs", "logs")).resolve()
         self.dryrun = "dryrun" in defaults
         self.pid_file = Path(defaults.get("pid", "running.pid")).resolve()
-        self.info_file = Path(defaults.get("info", "running.info")).resolve()
         self.config_file = Path(defaults.get("conffile", str(self.config_file))).resolve()
         self.report_dir = Path(defaults.get("reports", "reports")).resolve()
 
@@ -676,8 +675,7 @@ class Branch:
 
         if not info and not self.repo.warnings:
             return
-        runs = { self.name : info }
-        data = slack.build_runs(self.repo.name, runs, self.repo.warnings)
+        data = slack.build_runs(self.repo.name, self.name, info, self.repo.warnings)
 
         if not self.repo.runner.dryrun:
             slack.send(self.repo.runner, self.repo.slack_token, data)

--- a/nightlies.py
+++ b/nightlies.py
@@ -287,14 +287,7 @@ class NightlyRunner:
                 self.save()
 
                 branch.run()
-            except subprocess.CalledProcessError as e:
-                branch.repo.fatalerror = f"Process {format_cmd(e.cmd)} returned error code {e.returncode}"
-                self.log(1, branch.repo.fatalerror)
             finally:
-                if all([idx <= i for idx, b in enumerate(plan) if branch.repo == b.repo]):
-                    self.log(0, f"Finished nightly run for {branch.repo.name}")
-                    branch.repo.post()
-
                 del self.data["repo"]
                 del self.data["branch"]
                 # del self.data["runs_done"]
@@ -330,7 +323,6 @@ class Repository:
         self.image_file_name = configuration.get("image")
         
         self.branches : Dict[str, Branch] = {}
-        self.fatalerror: Optional[str] = None
         self.warnings: Dict[str, str] = {}
 
     def list_branches(self) -> List[str]:
@@ -451,7 +443,6 @@ class Repository:
                 branch.badges.append(f"pr#{pr}")
 
     def plan(self) -> None:
-
         self.runner.log(1, "Filtering branches " + ", ".join(self.branches))
         self.runnable = [branch for branch in self.branches.values() if branch.plan()]
         for branch in self.branches.values():
@@ -480,30 +471,8 @@ class Repository:
             self.runner.log(1, msg)
 
         data = slack.build_fatal(self.name, msg)
-        if not self.runner.dryrun:
-            slack.send(self.runner, self.slack_token, data)
+        slack.send(self.runner, self.slack_token, data)
 
-    def post(self) -> None:
-        if not self.slack_token:
-            return self.runner.log(1, f"Not posting to Slack, slack not configured")
-        elif not self.runner.base_url:
-            return self.runner.log(1, f"Not posting to Slack, baseurl not configured")
-        elif not hasattr(self, "runnable"):
-            return self.runner.log(1, f"Not posting to Slack, some kind of error occurred")
-        else:
-            runner.log(1, f"Posting results of run to slack!")
-
-        if self.fatalerror:
-            data = slack.build_fatal(self.name, self.fatalerror)
-        else:
-            runs = { branch.name : branch.info for branch in self.runnable if branch.info }
-            if not runs and not self.warnings:
-                return
-            data = slack.build_runs(self.name, runs, self.warnings)
-
-
-        if not self.runner.dryrun or self.fatalerror:
-            slack.send(self.runner, self.slack_token, data)
 
 class Branch:
     def __init__(self, repo : Repository, name : str):
@@ -513,7 +482,6 @@ class Branch:
         self.dir = self.repo.dir / self.filename
         self.lastcommit = self.repo.dir / (self.filename + ".json")
         self.badges : List[str] = []
-        self.info : Dict[str, str] = {}
         self.config : Dict[str, Any] = {}
 
         self.report_dir = self.dir / self.repo.report_dir_name if self.repo.report_dir_name else None
@@ -569,6 +537,7 @@ class Branch:
         self.repo.runner.log(0, f"Running branch {self.name} on repo {self.repo.name}")
         date = datetime.now()
         log_name = f"{date:%Y-%m-%d}-{date:%H%M%S}-{self.repo.name}-{self.filename}.log"
+        info : Dict[str, str] = {}
 
         self.repo.runner.data["branch_log"] = log_name
         self.repo.runner.save()
@@ -576,7 +545,7 @@ class Branch:
         # Store log URL for slack notifications
         if self.repo.runner.base_url:
             import urllib.parse
-            self.info["logurl"] = self.repo.runner.base_url + "logs/" + urllib.parse.quote(log_name)
+            info["logurl"] = self.repo.runner.base_url + "logs/" + urllib.parse.quote(log_name)
 
         t = datetime.now()
         try:
@@ -605,7 +574,7 @@ class Branch:
             self.repo.runner.log(1, f"Run on branch {self.name} timed out after {format_time(e.timeout)}")
             failure = "timeout"
         except subprocess.CalledProcessError as e:
-            self.repo.runner.log(1, f"Run on branch {self.name} failed with error code {e.returncode}")
+            self.post_fatal(f"Process {format_cmd(e.cmd)} returned error code {e.returncode}")
             failure = "failure"
         else:
             self.repo.runner.log(1, f"Successfully ran on branch {self.name}")
@@ -648,7 +617,7 @@ class Branch:
                     )
 
                 # Auto-publish report if configured
-                if "url" not in self.info:
+                if "url" not in info:
                     assert self.repo.runner.base_url, f"Cannot publish, no baseurl configured"
                     name = f"{int(time.time())}:{self.filename}:{out[:8]}"
                     dest_dir = self.repo.runner.report_dir / self.repo.name / name
@@ -657,11 +626,11 @@ class Branch:
                         self.repo.runner.log(2, f"Publishing report directory {self.report_dir} to {dest_dir}")
                         copything(self.report_dir, dest_dir)
                         url_base = self.repo.runner.base_url + "reports/" + self.repo.name + "/" + name
-                        self.info["url"] = url_base
+                        info["url"] = url_base
                         if self.image_file and self.image_file.exists():
                             self.repo.runner.log(2, f"Linking image file {self.image_file}")
                             path = self.image_file.relative_to(self.report_dir)
-                            self.info["img"] = url_base + "/" + str(path)
+                            info["img"] = url_base + "/" + str(path)
                         shutil.rmtree(self.report_dir, ignore_errors=True)
                     elif dest_dir.exists():
                         self.repo.runner.log(2, f"Destination directory {dest_dir} already exists, skipping")
@@ -669,8 +638,8 @@ class Branch:
                         self.repo.runner.log(2, f"Report directory {self.report_dir} does not exist")
 
 
-        self.info["result"] = f"*{failure}*" if failure else "success"
-        self.info["time"] = format_time((datetime.now() - t).seconds)
+        info["result"] = f"*{failure}*" if failure else "success"
+        info["time"] = format_time((datetime.now() - t).seconds)
 
         log_file = self.repo.runner.log_dir / log_name
         if log_file.exists() and log_file.stat().st_size > 10 * 1024 * 1024:
@@ -684,6 +653,34 @@ class Branch:
 
         del self.repo.runner.data["branch_log"]
         self.repo.runner.save()
+        self.post(info)
+
+    def post_fatal(self, msg: str) -> None:
+        if not self.repo.slack_token:
+            return self.repo.runner.log(1, f"Not posting to Slack, slack not configured")
+        elif not self.repo.runner.base_url:
+            return self.repo.runner.log(1, f"Not posting to Slack, baseurl not configured")
+        else:
+            self.repo.runner.log(1, msg)
+
+        data = slack.build_fatal(self.repo.name, msg)
+        slack.send(self.repo.runner, self.repo.slack_token, data)
+
+    def post(self, info: Dict[str, str]) -> None:
+        if not self.repo.slack_token:
+            return self.repo.runner.log(1, f"Not posting to Slack, slack not configured")
+        elif not self.repo.runner.base_url:
+            return self.repo.runner.log(1, f"Not posting to Slack, baseurl not configured")
+        else:
+            self.repo.runner.log(1, f"Posting results of run to slack!")
+
+        if not info and not self.repo.warnings:
+            return
+        runs = { self.name : info }
+        data = slack.build_runs(self.repo.name, runs, self.repo.warnings)
+
+        if not self.repo.runner.dryrun:
+            slack.send(self.repo.runner, self.repo.slack_token, data)
 
 
 if __name__ == "__main__":

--- a/slack.py
+++ b/slack.py
@@ -107,7 +107,6 @@ class Button(Accessory):
 def build_runs(
     name : str,
     runs : Dict[str, Dict[str, str]],
-    baseurl : str,
     warnings : Optional[Dict[str, str]] = None,
 ) -> Response:
     res = Response(f"Nightly data for {name}")
@@ -122,10 +121,8 @@ def build_runs(
             text += " " + info["emoji"]
         block = TextBlock(text)
 
-        if "success" != result:
-            file = os.path.basename(info["file"])
-            url = baseurl + "logs/" + urllib.parse.quote(file)
-            btn = Button("Error log", url, style="primary")
+        if "success" != result and info.get("logurl"):
+            btn = Button("Error log", info["logurl"], style="primary")
             block.add(btn)
         elif "url" in info:
             btn = Button("View Report", info["url"])
@@ -147,7 +144,7 @@ def build_runs(
             res.add(img)
     return res
     
-def build_fatal(name : str, text : str, baseurl : str) -> Response:
+def build_fatal(name : str, text : str) -> Response:
     res = Response(f"Fatal error running nightlies for {name}")
     res.add(TextBlock(text))
     return res

--- a/slack.py
+++ b/slack.py
@@ -48,28 +48,6 @@ class TextBlock(Block):
         assert not self.accessory, "This Block already has an Accessory"
         self.accessory = accessory
         
-class Fields(Block):
-    def __init__(self, fields : Dict[str, str]):
-        self.fields = fields
-
-    def to_json(self) -> Dict[str, Any]:
-        fields : List[Dict[str, Any]] = []
-        for k, v in self.fields.items():
-            fields.append({
-                "type": "mrkdwn",
-                "text": "*" + k.title() + "*",
-            })
-            fields.append({
-                "type": "mrkdwn",
-                "text": v,
-            })
-
-        block = {
-            "type": "section",
-            "fields": fields,
-        }
-        return block
-        
 class Image(Block):
     def __init__(self, text : str, url : str):
         self.text = text
@@ -106,42 +84,34 @@ class Button(Accessory):
 
 def build_runs(
     name : str,
-    runs : Dict[str, Dict[str, str]],
+    branch : str,
+    info : Dict[str, str],
     warnings : Optional[Dict[str, str]] = None,
 ) -> Response:
     res = Response(f"Nightly data for {name}")
     if warnings:
         for key in sorted(warnings):
             res.add(TextBlock(f":warning: {warnings[key]}"))
-    for branch, info in runs.items():
-        result = info["result"]
-        time = info["time"]
-        text = f"Branch `{branch}` of `{name}` was a {result} in {time}"
-        if "emoji" in info:
-            text += " " + info["emoji"]
-        block = TextBlock(text)
+    
+    result = info["result"]
+    time = info["time"]
+    text = f"Branch `{branch}` of `{name}` was a {result} in {time}"
+    block = TextBlock(text)
 
-        if "success" != result and info.get("logurl"):
-            btn = Button("Error log", info["logurl"], style="primary")
-            block.add(btn)
-        elif "url" in info:
-            btn = Button("View Report", info["url"])
-            block.add(btn)
+    if "success" != result and info.get("logurl"):
+        btn = Button("Error log", info["logurl"], style="primary")
+        block.add(btn)
+    elif "url" in info:
+        btn = Button("View Report", info["url"])
+        block.add(btn)
 
-        res.add(block)
+    res.add(block)
 
-        fields = {
-            k: v for k, v in info.items()
-            if k not in ["url", "emoji", "result", "time", "img", "file"]
-        }
-        if fields:
-            res.add(Fields(fields))
-
-        if "img" in info:
-            url, *alttext = info["img"].split(" ")
-            text = " ".join(alttext) or f"Image for {name} branch {branch}"
-            img = Image(text, url)
-            res.add(img)
+    if "img" in info:
+        url, *alttext = info["img"].split(" ")
+        text = " ".join(alttext) or f"Image for {name} branch {branch}"
+        img = Image(text, url)
+        res.add(img)
     return res
     
 def build_fatal(name : str, text : str) -> Response:


### PR DESCRIPTION
This PR does a lot of stuff:

- Slack messages are sent our per-branch, as each branch completes. It's a little more annoying now, I think, since it's more Slack noise, but the benefit is that it will generalize to concurrent runs.
- I refactored the `fatalerror` state into a separate method, `post_fatal`. Not thrilled with the naming, but whatever. The point is that this is one less bit of shared state, which moves us toward separating out the runner.
- I also moved `info` from state into a local variable. Same deal, less state good.
- Along the way, I refactored how `slack.py` worked, and ended up deleting actually quite a bit of code.

I think the next step in the refactor is to figure out what we're going to do with logging. Probably we just log the branch to its own file? Anyway, less state is the goal.