### PR TITLE
Add support for configuring PPAs

### DIFF
--- a/nightlies.py
+++ b/nightlies.py
@@ -362,6 +362,17 @@ class Repository:
         self.runner.log(0, "Beginning nightly run for " + self.name)
         self.dir.mkdir(parents=True, exist_ok=True)
 
+        ppas = self.config.get("ppa", "").split()
+        if ppas:
+            failed_ppas = apt.add_repositories(self.runner, ppas)
+            if failed_ppas:
+                joined = ", ".join(failed_ppas)
+                self.warnings["ppa"] = (
+                    f"Failed to add apt repository {joined}"
+                    if len(failed_ppas) == 1
+                    else f"Failed to add apt repositories {joined}"
+                )
+
         pkgs = self.config.get("apt", "").split()
         if pkgs and apt.check_updates(self.runner, pkgs):
             if not self.runner.dryrun:

--- a/views/docs.view
+++ b/views/docs.view
@@ -134,6 +134,11 @@ Debian packages are the preferred way to manage dependencies. If you
 have some dependency that you absolutely can't install from a package,
 get in touch with the nightly maintainers.</dd>
 
+<dt><code>ppa</code></dt>
+<dd>A space-separated list of PPA repositories (like
+<code>ppa:owner/name</code>) to enable before installing Debian
+packages. Invalid repositories are skipped and reported as warnings.</dd>
+
 <dt><code>timeout</code></dt>
 <dd>You can give a timeout (written <code>4hr</code> or similar).
 After the timeout is over, your nightly will be killed. This is


### PR DESCRIPTION
## Summary
- add support for installing PPA repositories before apt packages run
- surface failures to add PPAs as Slack warnings instead of aborting the nightly
- document the new `ppa` configuration key

## Testing
- mypy

------
https://chatgpt.com/codex/tasks/task_e_68d166de08988331a1253f37b526bd0b