### PR TITLE
Skip already-added PPAs before running `add-apt-repository`

### DIFF
--- a/apt.py
+++ b/apt.py
@@ -44,22 +44,22 @@ def _has_repository(
     source_list: Path = Path("/etc/apt/sources.list"),
     sources_dir: Path = Path("/etc/apt/sources.list.d"),
 ) -> bool:
-    if not repo.startswith("ppa:"):
+    if not repo.startswith("ppa:") or repo.count("/") != 1:
         return False
 
-    parts = repo[4:].split("/")
-    if len(parts) != 2 or not parts[0] or not parts[1]:
-        return False
-    owner, name = parts
-    ppa_path = f"/{owner}/{name}/ubuntu"
+    ppa_path = f"/{repo[4:]}/ubuntu"
 
     for path in _apt_source_files(source_list, sources_dir):
         try:
             contents = path.read_text(errors="ignore")
         except OSError:
             continue
-        if "launchpad" in contents and ppa_path in contents:
-            return True
+        for line in contents.splitlines():
+            if not line.startswith("URIs:"):
+                continue
+            uri = line.removeprefix("URIs:").strip()
+            if ppa_path in uri:
+                return True
     return False
 
 

--- a/apt.py
+++ b/apt.py
@@ -1,10 +1,12 @@
 from dataclasses import dataclass
+from pathlib import Path
 from typing import List, Sequence, TYPE_CHECKING
-import re
 import subprocess
 
 if TYPE_CHECKING:
     import nightlies
+
+import re
 
 APT_LINE_RE = re.compile(r"^(\d+) upgraded, (\d+) newly installed, (\d+) to remove and (\d+) not upgraded\.$", re.MULTILINE)
 APT_INST_RE = re.compile(r"^Inst (\S+)(?: \[([^\]]+)\])? \(([^)]+)\)")
@@ -24,9 +26,49 @@ def _format_cmd(cmd: Sequence[object]) -> str:
     return " ".join(str(part) for part in cmd)
 
 
+def _apt_source_files(
+    source_list: Path = Path("/etc/apt/sources.list"),
+    sources_dir: Path = Path("/etc/apt/sources.list.d"),
+) -> List[Path]:
+    files: List[Path] = []
+    if source_list.is_file():
+        files.append(source_list)
+    if sources_dir.is_dir():
+        for path in sorted(sources_dir.iterdir()):
+            if path.is_file():
+                files.append(path)
+    return files
+
+def _has_repository(
+    repo: str,
+    source_list: Path = Path("/etc/apt/sources.list"),
+    sources_dir: Path = Path("/etc/apt/sources.list.d"),
+) -> bool:
+    if not repo.startswith("ppa:"):
+        return False
+
+    parts = repo[4:].split("/")
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        return False
+    owner, name = parts
+    ppa_path = f"/{owner}/{name}/ubuntu"
+
+    for path in _apt_source_files(source_list, sources_dir):
+        try:
+            contents = path.read_text(errors="ignore")
+        except OSError:
+            continue
+        if "launchpad" in contents and ppa_path in contents:
+            return True
+    return False
+
+
 def add_repositories(runner: "nightlies.NightlyRunner", repos: Sequence[str]) -> List[str]:
     failed: List[str] = []
     for repo in repos:
+        if _has_repository(repo):
+            runner.log(1, f"Apt repository {repo} already present; skipping")
+            continue
         runner.log(1, f"Adding apt repository {repo}")
         if runner.dryrun:
             continue

--- a/test/test_nightlies.py
+++ b/test/test_nightlies.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 # Ensure direct execution (uv run test/test_nightlies.py) resolves project modules from repo root.
 ROOT = Path(__file__).resolve().parent.parent
@@ -17,6 +18,68 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from nightlies import NightlyRunner
+import apt
+
+
+class FakeRunner:
+    def __init__(self, dryrun: bool = False) -> None:
+        self.dryrun = dryrun
+        self.logs: list[tuple[int, str]] = []
+        self.commands: list[list[str]] = []
+
+    def log(self, level: int, message: str) -> None:
+        self.logs.append((level, message))
+
+    def exec(self, level: int, cmd: list[str]) -> subprocess.CompletedProcess[bytes]:
+        self.commands.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout=b"", stderr=b"")
+
+
+class TestApt(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmpdir = Path(tempfile.mkdtemp(prefix="apt-test-"))
+        self.source_list = self.tmpdir / "sources.list"
+        self.sources_dir = self.tmpdir / "sources.list.d"
+        self.sources_dir.mkdir()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmpdir)
+
+    def test_add_repositories_skips_existing_ppa(self) -> None:
+        (self.sources_dir / "owner-name.list").write_text(
+            "deb https://ppa.launchpadcontent.net/owner/name/ubuntu noble main\n"
+        )
+        runner = FakeRunner()
+
+        with mock.patch.object(apt, "_has_repository", return_value=True):
+            failed = apt.add_repositories(runner, ["ppa:owner/name"])
+
+        self.assertEqual(failed, [])
+        self.assertEqual(runner.commands, [])
+        self.assertIn((1, "Apt repository ppa:owner/name already present; skipping"), runner.logs)
+
+    def test_add_repositories_adds_missing_ppa(self) -> None:
+        runner = FakeRunner()
+
+        with mock.patch.object(apt, "_has_repository", return_value=False):
+            failed = apt.add_repositories(runner, ["ppa:owner/name"])
+
+        self.assertEqual(failed, [])
+        self.assertEqual(
+            runner.commands,
+            [["sudo", "add-apt-repository", "--yes", "ppa:owner/name"]],
+        )
+
+    def test_has_repository_matches_launchpad_sources(self) -> None:
+        (self.source_list).write_text(
+            "Types: deb\n"
+            "URIs: https://ppa.launchpadcontent.net/owner/name/ubuntu\n"
+            "Suites: noble\n"
+            "Components: main\n"
+        )
+
+        self.assertTrue(apt._has_repository("ppa:owner/name", self.source_list, self.sources_dir))
+        self.assertFalse(apt._has_repository("ppa:other/name", self.source_list, self.sources_dir))
 
 
 class TestNightlyRunnerHarness(unittest.TestCase):


### PR DESCRIPTION
Apparently `add-apt-repository` can be slow or even fail, and we only really need to do it once. This PR thus checks if a repo has already been added before trying to add it.