### PR TITLE
Add nightly_info.json to published reports

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from typing import Any, Dict, List, Optional, Sequence
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 import gzip, json, shlex, shutil, subprocess, sys, time
 import signal
@@ -87,6 +87,41 @@ def save_metadata(metadata_file: Path, data: Dict[str, Any]) -> None:
     with metadata_file.open("w") as f:
         json.dump(data, f)
 
+def format_time_iso_utc(ts: datetime) -> str:
+    return ts.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+def write_nightly_info(
+    report_dir: Path,
+    *,
+    bc: config.BranchConfig,
+    commit: str,
+    status: str,
+    started_at: datetime,
+    finished_at: datetime,
+    log_name: str,
+    log_url: str | None,
+    report_url: str | None,
+    image_url: str | None,
+) -> None:
+    duration_seconds = (finished_at - started_at).total_seconds()
+    with (report_dir / "nightly_info.json").open("w") as f:
+        json.dump({
+            "repo": bc.repo_name,
+            "branch": bc.branch_name,
+            "branch_filename": bc.branch_filename,
+            "commit": commit,
+            "commit_short": commit[:8],
+            "status": status,
+            "started_at": format_time_iso_utc(started_at),
+            "finished_at": format_time_iso_utc(finished_at),
+            "duration_seconds": duration_seconds,
+            "duration_human": format_time(duration_seconds),
+            "log": log_name,
+            "log_url": log_url,
+            "report_url": report_url,
+            "image_url": image_url,
+        }, f)
+
 def run_branch(bc: config.BranchConfig, log_name: str) -> int:
     log(f"Running branch {bc.branch_name} on repo {bc.repo_name}")
     info: Dict[str, str] = {}
@@ -101,7 +136,7 @@ def run_branch(bc: config.BranchConfig, log_name: str) -> int:
         log(f"Received signal {signum}")
         info["result"] = "*killed*"
         if start is not None:
-            info["time"] = format_time((datetime.now() - start).seconds)
+            info["time"] = format_time((datetime.now(timezone.utc) - start).total_seconds())
         log("Posting killed result to slack")
         if slack_output:
             try:
@@ -120,7 +155,7 @@ def run_branch(bc: config.BranchConfig, log_name: str) -> int:
         capture_output=True, check=True
     ).stdout.decode("ascii").strip()
 
-    start = datetime.now()
+    start = datetime.now(timezone.utc)
     try:
         to = parse_time(bc.timeout)
         cmd = ["make", "-C", str(bc.branch_dir), "nightly"]
@@ -136,12 +171,12 @@ def run_branch(bc: config.BranchConfig, log_name: str) -> int:
 
     except subprocess.TimeoutExpired as e:
         log(f"Run on branch {bc.branch_name} timed out after {format_time(e.timeout)}")
-        failure = "timeout"
+        status = "timeout"
     except subprocess.CalledProcessError:
-        failure = "failure"
+        status = "failure"
     else:
         log(f"Successfully ran on branch {bc.branch_name}")
-        failure = ""
+        status = "success"
 
     metadata = read_metadata(bc.metadata_file)
     metadata["commit"] = out
@@ -150,6 +185,30 @@ def run_branch(bc: config.BranchConfig, log_name: str) -> int:
 
     if bc.report_dir and bc.report_dir.exists():
         try:
+            finished_at = datetime.now(timezone.utc)
+            log_url = info.get("logurl")
+            report_url = None
+            image_url = None
+            if bc.base_url:
+                name = f"{int(time.time())}:{bc.branch_filename}:{out[:8]}"
+                report_url = bc.base_url + "reports/" + bc.repo_name + "/" + name
+                if bc.image_file and bc.image_file.exists():
+                    path = bc.image_file.relative_to(bc.report_dir)
+                    image_url = report_url + "/" + str(path)
+
+            write_nightly_info(
+                bc.report_dir,
+                bc=bc,
+                commit=out,
+                status=status,
+                started_at=start,
+                finished_at=finished_at,
+                log_name=log_name,
+                log_url=log_url,
+                report_url=report_url,
+                image_url=image_url,
+            )
+
             if bc.gzip:
                 log(f"GZipping all {bc.gzip} files")
                 gzip_matching_files(bc.report_dir, shlex.split(bc.gzip))
@@ -165,18 +224,17 @@ def run_branch(bc: config.BranchConfig, log_name: str) -> int:
                     slack_output.warn("report-size", msg)
 
             if "url" not in info and bc.base_url:
-                name = f"{int(time.time())}:{bc.branch_filename}:{out[:8]}"
+                assert report_url is not None
                 dest_dir = bc.reports_dir / bc.repo_name / name
 
                 if bc.report_dir.exists():
                     log(f"Publishing report directory {bc.report_dir} to {dest_dir}")
                     copything(bc.report_dir, dest_dir)
-                    url_base = bc.base_url + "reports/" + bc.repo_name + "/" + name
-                    info["url"] = url_base
+                    info["url"] = report_url
                     if bc.image_file and bc.image_file.exists():
                         log(f"Linking image file {bc.image_file}")
-                        path = bc.image_file.relative_to(bc.report_dir)
-                        info["img"] = url_base + "/" + str(path)
+                        assert image_url is not None
+                        info["img"] = image_url
                     shutil.rmtree(bc.report_dir, ignore_errors=True)
                 else:
                     log(f"Report directory {bc.report_dir} does not exist")
@@ -206,8 +264,8 @@ def run_branch(bc: config.BranchConfig, log_name: str) -> int:
         if slack_output:
             slack_output.warn("log-size", msg)
 
-    info["result"] = f"*{failure}*" if failure else "success"
-    info["time"] = format_time((datetime.now() - start).seconds)
+    info["result"] = f"*{status}*" if status != "success" else "success"
+    info["time"] = format_time((datetime.now(timezone.utc) - start).total_seconds())
 
     if slack_output:
         log("Posting results of run to slack!")
@@ -230,7 +288,7 @@ def run_branch(bc: config.BranchConfig, log_name: str) -> int:
         assert max_rss is not None, f"sstat returned unknown MaxRSS: {output!r}"
         log(f"Nightly used memory={format_size(max_rss).lower()}, timeout={info['time']}")
 
-    return 1 if failure else 0
+    return 1 if status != "success" else 0
 
 
 def main() -> int:

--- a/runner.py
+++ b/runner.py
@@ -91,24 +91,24 @@ def format_time_iso_utc(ts: datetime) -> str:
     return ts.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
 
 def write_nightly_info(
-    report_dir: Path,
+    branch_config: config.BranchConfig,
     *,
-    bc: config.BranchConfig,
     commit: str,
     status: str,
     started_at: datetime,
     finished_at: datetime,
-    log_name: str,
-    log_url: str | None,
-    report_url: str | None,
+    log: str,
+    log_url: str,
+    report_url: str,
     image_url: str | None,
 ) -> None:
     duration_seconds = (finished_at - started_at).total_seconds()
-    with (report_dir / "nightly_info.json").open("w") as f:
+    assert branch_config.report_dir is not None
+    with (branch_config.report_dir / "nightly_info.json").open("w") as f:
         json.dump({
-            "repo": bc.repo_name,
-            "branch": bc.branch_name,
-            "branch_filename": bc.branch_filename,
+            "repo": branch_config.repo_name,
+            "branch": branch_config.branch_name,
+            "branch_filename": branch_config.branch_filename,
             "commit": commit,
             "commit_short": commit[:8],
             "status": status,
@@ -116,7 +116,7 @@ def write_nightly_info(
             "finished_at": format_time_iso_utc(finished_at),
             "duration_seconds": duration_seconds,
             "duration_human": format_time(duration_seconds),
-            "log": log_name,
+            "log": log,
             "log_url": log_url,
             "report_url": report_url,
             "image_url": image_url,
@@ -185,30 +185,6 @@ def run_branch(bc: config.BranchConfig, log_name: str) -> int:
 
     if bc.report_dir and bc.report_dir.exists():
         try:
-            finished_at = datetime.now(timezone.utc)
-            log_url = info.get("logurl")
-            report_url = None
-            image_url = None
-            if bc.base_url:
-                name = f"{int(time.time())}:{bc.branch_filename}:{out[:8]}"
-                report_url = bc.base_url + "reports/" + bc.repo_name + "/" + name
-                if bc.image_file and bc.image_file.exists():
-                    path = bc.image_file.relative_to(bc.report_dir)
-                    image_url = report_url + "/" + str(path)
-
-            write_nightly_info(
-                bc.report_dir,
-                bc=bc,
-                commit=out,
-                status=status,
-                started_at=start,
-                finished_at=finished_at,
-                log_name=log_name,
-                log_url=log_url,
-                report_url=report_url,
-                image_url=image_url,
-            )
-
             if bc.gzip:
                 log(f"GZipping all {bc.gzip} files")
                 gzip_matching_files(bc.report_dir, shlex.split(bc.gzip))
@@ -224,10 +200,27 @@ def run_branch(bc: config.BranchConfig, log_name: str) -> int:
                     slack_output.warn("report-size", msg)
 
             if "url" not in info and bc.base_url:
-                assert report_url is not None
+                name = f"{int(time.time())}:{bc.branch_filename}:{out[:8]}"
                 dest_dir = bc.reports_dir / bc.repo_name / name
+                report_url = bc.base_url + "reports/" + bc.repo_name + "/" + name
 
                 if bc.report_dir.exists():
+                    image_url = None
+                    if bc.image_file and bc.image_file.exists():
+                        path = bc.image_file.relative_to(bc.report_dir)
+                        image_url = report_url + "/" + str(path)
+                    if status == "success":
+                        write_nightly_info(
+                            bc,
+                            commit=out,
+                            status=status,
+                            started_at=start,
+                            finished_at=datetime.now(timezone.utc),
+                            log=log_name,
+                            log_url=bc.base_url + "logs/" + urllib.parse.quote(log_name),
+                            report_url=report_url,
+                            image_url=image_url,
+                        )
                     log(f"Publishing report directory {bc.report_dir} to {dest_dir}")
                     copything(bc.report_dir, dest_dir)
                     info["url"] = report_url

--- a/test/test_nightlies.py
+++ b/test/test_nightlies.py
@@ -395,13 +395,7 @@ class TestNightlyRunnerHarness(unittest.TestCase):
         self.assertIn('"commit"', contents)
         self.assertIn('"time"', contents)
         report_dir = self.published_report(result)
-        info = json.loads((report_dir / "nightly_info.json").read_text())
-        self.assertEqual(info["status"], "timeout")
-        self.assertEqual(
-            info["report_url"],
-            "https://nightlies.example/reports/testrepo/" + report_dir.name,
-        )
-        self.assertEqual(info["log"], "timeout.log")
+        self.assertFalse((report_dir / "nightly_info.json").exists())
 
     def test_runner_writes_metadata_for_successful_run(self) -> None:
         self.makefile("add simple nightly target", ["echo ok"])

--- a/test/test_nightlies.py
+++ b/test/test_nightlies.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import configparser
+import json
 import os
 import shutil
 import subprocess
@@ -218,6 +219,23 @@ class TestNightlyRunnerHarness(unittest.TestCase):
         published = report_dir / "index.html"
         self.assertTrue(published.exists())
         self.assertEqual(published.read_text(), "<h1>ok</h1>\n")
+        info = json.loads((report_dir / "nightly_info.json").read_text())
+        self.assertEqual(info["repo"], "testrepo")
+        self.assertEqual(info["branch"], "main")
+        self.assertEqual(info["branch_filename"], "main")
+        self.assertEqual(info["status"], "success")
+        self.assertRegex(info["commit"], r"^[0-9a-f]{40}$")
+        self.assertEqual(info["commit_short"], info["commit"][:8])
+        self.assertEqual(info["log"], "publish-report.log")
+        self.assertEqual(
+            info["report_url"],
+            "https://nightlies.example/reports/testrepo/" + report_dir.name,
+        )
+        self.assertEqual(
+            info["log_url"],
+            "https://nightlies.example/logs/publish-report.log",
+        )
+        self.assertIsNone(info["image_url"])
         # Published reports should be moved out of the worktree so later runs start clean.
         self.assertFalse((self.repos_dir / "testrepo" / "main" / "report").exists())
 
@@ -376,6 +394,14 @@ class TestNightlyRunnerHarness(unittest.TestCase):
         contents = metadata.read_text()
         self.assertIn('"commit"', contents)
         self.assertIn('"time"', contents)
+        report_dir = self.published_report(result)
+        info = json.loads((report_dir / "nightly_info.json").read_text())
+        self.assertEqual(info["status"], "timeout")
+        self.assertEqual(
+            info["report_url"],
+            "https://nightlies.example/reports/testrepo/" + report_dir.name,
+        )
+        self.assertEqual(info["log"], "timeout.log")
 
     def test_runner_writes_metadata_for_successful_run(self) -> None:
         self.makefile("add simple nightly target", ["echo ok"])

--- a/views/docs.view
+++ b/views/docs.view
@@ -89,8 +89,9 @@ metadata about the run, such as branch, commit, status, timing, and
 report/log URLs.</p>
 
 <p>The <code>nightly_info.json</code> file is written by the runner at
-the top level of the report directory. It contains a single JSON
-object with these keys:</p>
+the top level of the report directory, but only when the nightly run
+itself succeeds and the report is published. It contains a single JSON object with these
+keys:</p>
 
 <dl>
 <dt><code>repo</code></dt>
@@ -132,13 +133,10 @@ names.</dd>
 <dd>The log file name for the run.</dd>
 
 <dt><code>log_url</code></dt>
-<dd>The absolute URL to the log file when <code>baseurl</code> is
-configured, otherwise <code>null</code>.</dd>
+<dd>The absolute URL to the log file for the run.</dd>
 
 <dt><code>report_url</code></dt>
-<dd>The absolute URL to the published report directory when the report
-is published under a configured <code>baseurl</code>, otherwise
-<code>null</code>.</dd>
+<dd>The absolute URL to the published report directory.</dd>
 
 <dt><code>image_url</code></dt>
 <dd>The absolute URL to the configured report image when one exists,

--- a/views/docs.view
+++ b/views/docs.view
@@ -83,7 +83,67 @@ you might generate as output.</p>
 
 <p>Now when the nightly runs, that directory will be archived and the
 nightly Slack message will have a button to go to
-the <code>index.html</code> file.</p>
+the <code>index.html</code> file. Published reports also include a
+runner-generated <code>nightly_info.json</code> file with basic
+metadata about the run, such as branch, commit, status, timing, and
+report/log URLs.</p>
+
+<p>The <code>nightly_info.json</code> file is written by the runner at
+the top level of the report directory. It contains a single JSON
+object with these keys:</p>
+
+<dl>
+<dt><code>repo</code></dt>
+<dd>The short repository name used in report paths.</dd>
+
+<dt><code>branch</code></dt>
+<dd>The branch name that was run, like <code>main</code> or
+<code>feature/test</code>.</dd>
+
+<dt><code>branch_filename</code></dt>
+<dd>The escaped branch name used on disk and in report directory
+names.</dd>
+
+<dt><code>commit</code></dt>
+<dd>The full git commit SHA that the runner checked out and ran.</dd>
+
+<dt><code>commit_short</code></dt>
+<dd>The first 8 characters of <code>commit</code>.</dd>
+
+<dt><code>status</code></dt>
+<dd>The final run result: <code>success</code>,
+<code>failure</code>, <code>timeout</code>, or
+<code>killed</code>.</dd>
+
+<dt><code>started_at</code></dt>
+<dd>The run start time in UTC ISO 8601 format.</dd>
+
+<dt><code>finished_at</code></dt>
+<dd>The run finish time in UTC ISO 8601 format.</dd>
+
+<dt><code>duration_seconds</code></dt>
+<dd>The wall-clock runtime as a number of seconds.</dd>
+
+<dt><code>duration_human</code></dt>
+<dd>The runtime formatted for people, like <code>42.0s</code> or
+<code>3.5m</code>.</dd>
+
+<dt><code>log</code></dt>
+<dd>The log file name for the run.</dd>
+
+<dt><code>log_url</code></dt>
+<dd>The absolute URL to the log file when <code>baseurl</code> is
+configured, otherwise <code>null</code>.</dd>
+
+<dt><code>report_url</code></dt>
+<dd>The absolute URL to the published report directory when the report
+is published under a configured <code>baseurl</code>, otherwise
+<code>null</code>.</dd>
+
+<dt><code>image_url</code></dt>
+<dd>The absolute URL to the configured report image when one exists,
+otherwise <code>null</code>.</dd>
+</dl>
 
 <h2>Customizing the nightly</h2>
 

--- a/views/docs.view
+++ b/views/docs.view
@@ -83,65 +83,7 @@ you might generate as output.</p>
 
 <p>Now when the nightly runs, that directory will be archived and the
 nightly Slack message will have a button to go to
-the <code>index.html</code> file. Published reports also include a
-runner-generated <code>nightly_info.json</code> file with basic
-metadata about the run, such as branch, commit, status, timing, and
-report/log URLs.</p>
-
-<p>The <code>nightly_info.json</code> file is written by the runner at
-the top level of the report directory, but only when the nightly run
-itself succeeds and the report is published. It contains a single JSON object with these
-keys:</p>
-
-<dl>
-<dt><code>repo</code></dt>
-<dd>The short repository name used in report paths.</dd>
-
-<dt><code>branch</code></dt>
-<dd>The branch name that was run, like <code>main</code> or
-<code>feature/test</code>.</dd>
-
-<dt><code>branch_filename</code></dt>
-<dd>The escaped branch name used on disk and in report directory
-names.</dd>
-
-<dt><code>commit</code></dt>
-<dd>The full git commit SHA that the runner checked out and ran.</dd>
-
-<dt><code>commit_short</code></dt>
-<dd>The first 8 characters of <code>commit</code>.</dd>
-
-<dt><code>status</code></dt>
-<dd>The final run result: <code>success</code>,
-<code>failure</code>, <code>timeout</code>, or
-<code>killed</code>.</dd>
-
-<dt><code>started_at</code></dt>
-<dd>The run start time in UTC ISO 8601 format.</dd>
-
-<dt><code>finished_at</code></dt>
-<dd>The run finish time in UTC ISO 8601 format.</dd>
-
-<dt><code>duration_seconds</code></dt>
-<dd>The wall-clock runtime as a number of seconds.</dd>
-
-<dt><code>duration_human</code></dt>
-<dd>The runtime formatted for people, like <code>42.0s</code> or
-<code>3.5m</code>.</dd>
-
-<dt><code>log</code></dt>
-<dd>The log file name for the run.</dd>
-
-<dt><code>log_url</code></dt>
-<dd>The absolute URL to the log file for the run.</dd>
-
-<dt><code>report_url</code></dt>
-<dd>The absolute URL to the published report directory.</dd>
-
-<dt><code>image_url</code></dt>
-<dd>The absolute URL to the configured report image when one exists,
-otherwise <code>null</code>.</dd>
-</dl>
+the <code>index.html</code> file.</p>
 
 <h2>Customizing the nightly</h2>
 
@@ -238,4 +180,65 @@ requesting fewer cores can run concurrently with other jobs.</dd>
 <code>8gb</code> or <code>512mb</code>. If your job exceeds this limit,
 it will be killed. By default, there is no memory limit.</dd>
 
+</dl>
+
+<h2>nightly_info.json</h2>
+
+<p>Published reports include a runner-generated
+<code>nightly_info.json</code> file with basic metadata about the run,
+such as branch, commit, status, timing, and report/log URLs.</p>
+
+<p>The <code>nightly_info.json</code> file is written by the runner at
+the top level of the report directory, but only when the nightly run
+itself succeeds and the report is published. It contains a single JSON
+object with these keys:</p>
+
+<dl>
+<dt><code>repo</code></dt>
+<dd>The short repository name used in report paths.</dd>
+
+<dt><code>branch</code></dt>
+<dd>The branch name that was run, like <code>main</code> or
+<code>feature/test</code>.</dd>
+
+<dt><code>branch_filename</code></dt>
+<dd>The escaped branch name used on disk and in report directory
+names.</dd>
+
+<dt><code>commit</code></dt>
+<dd>The full git commit SHA that the runner checked out and ran.</dd>
+
+<dt><code>commit_short</code></dt>
+<dd>The first 8 characters of <code>commit</code>.</dd>
+
+<dt><code>status</code></dt>
+<dd>The final run result: <code>success</code>,
+<code>failure</code>, <code>timeout</code>, or
+<code>killed</code>.</dd>
+
+<dt><code>started_at</code></dt>
+<dd>The run start time in UTC ISO 8601 format.</dd>
+
+<dt><code>finished_at</code></dt>
+<dd>The run finish time in UTC ISO 8601 format.</dd>
+
+<dt><code>duration_seconds</code></dt>
+<dd>The wall-clock runtime as a number of seconds.</dd>
+
+<dt><code>duration_human</code></dt>
+<dd>The runtime formatted for people, like <code>42.0s</code> or
+<code>3.5m</code>.</dd>
+
+<dt><code>log</code></dt>
+<dd>The log file name for the run.</dd>
+
+<dt><code>log_url</code></dt>
+<dd>The absolute URL to the log file for the run.</dd>
+
+<dt><code>report_url</code></dt>
+<dd>The absolute URL to the published report directory.</dd>
+
+<dt><code>image_url</code></dt>
+<dd>The absolute URL to the configured report image when one exists,
+otherwise <code>null</code>.</dd>
 </dl>


### PR DESCRIPTION
# Summary

Add a runner-generated `nightly_info.json` file to every published report.

This gives report pages a stable, runner-owned source of metadata about the run
that produced the report, instead of requiring projects to expose that data
themselves.

# What Changed

- Write `nightly_info.json` into the top level of the report directory before
  publishing.
- Include runner-owned metadata for the published report:
  - `repo`
  - `branch`
  - `branch_filename`
  - `commit`
  - `commit_short`
  - `status`
  - `started_at`
  - `finished_at`
  - `duration_seconds`
  - `duration_human`
  - `log`
  - `log_url`
  - `report_url`
  - `image_url`
- Reuse the same computed report and image URLs when publishing, so the report
  contents and the Slack payload stay aligned.
- Document the new file and all of its keys in `views/docs.view`.
- Add tests covering the new metadata file for successful and timed out runs.
