### PR TITLE
Add file manifest to nightly_info.json

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -81,10 +81,10 @@ def report_files(directory: Path, compressed: set[Path]) -> List[Dict[str, Any]]
     for path in sorted(directory.rglob("*")):
         if not path.is_file():
             continue
-        stored_path = path.relative_to(directory)
+        report_path = path.relative_to(directory)
         files.append({
-            "stored_path": str(stored_path),
-            "gzip": stored_path in compressed,
+            "path": str(report_path),
+            "gzip": report_path in compressed,
         })
     return files
 

--- a/runner.py
+++ b/runner.py
@@ -65,13 +65,28 @@ def copything(src: Path, dst: Path) -> None:
     else:
         shutil.copy2(src, dst)
 
-def gzip_matching_files(directory: Path, globs: List[str]) -> None:
+def gzip_matching_files(directory: Path, globs: List[str]) -> set[Path]:
+    compressed: set[Path] = set()
     for path in directory.rglob("*"):
         if path.is_file() and any(path.match(g) for g in globs):
             gz_path = path.with_suffix(path.suffix + ".gz")
+            compressed.add(gz_path.relative_to(directory))
             with path.open("rb") as f_in, gzip.open(gz_path, "wb", compresslevel=9) as f_out:
                 shutil.copyfileobj(f_in, f_out)
             path.unlink()
+    return compressed
+
+def report_files(directory: Path, compressed: set[Path]) -> List[Dict[str, Any]]:
+    files: List[Dict[str, Any]] = []
+    for path in sorted(directory.rglob("*")):
+        if not path.is_file():
+            continue
+        stored_path = path.relative_to(directory)
+        files.append({
+            "stored_path": str(stored_path),
+            "gzip": stored_path in compressed,
+        })
+    return files
 
 def read_metadata(metadata_file: Path) -> Dict[str, Any]:
     if metadata_file.exists():
@@ -101,6 +116,7 @@ def write_nightly_info(
     log_url: str,
     report_url: str,
     image_url: str | None,
+    compressed: set[Path],
 ) -> None:
     duration_seconds = (finished_at - started_at).total_seconds()
     assert branch_config.report_dir is not None
@@ -120,6 +136,7 @@ def write_nightly_info(
             "log_url": log_url,
             "report_url": report_url,
             "image_url": image_url,
+            "files": report_files(branch_config.report_dir, compressed),
         }, f)
 
 def run_branch(bc: config.BranchConfig, log_name: str) -> int:
@@ -185,9 +202,10 @@ def run_branch(bc: config.BranchConfig, log_name: str) -> int:
 
     if bc.report_dir and bc.report_dir.exists():
         try:
+            compressed: set[Path] = set()
             if bc.gzip:
                 log(f"GZipping all {bc.gzip} files")
-                gzip_matching_files(bc.report_dir, shlex.split(bc.gzip))
+                compressed = gzip_matching_files(bc.report_dir, shlex.split(bc.gzip))
 
             total, biggest, _ = tree_size(bc.report_dir)
             if bc.warn_report and total > bc.warn_report:
@@ -220,6 +238,7 @@ def run_branch(bc: config.BranchConfig, log_name: str) -> int:
                             log_url=bc.base_url + "logs/" + urllib.parse.quote(log_name),
                             report_url=report_url,
                             image_url=image_url,
+                            compressed=compressed,
                         )
                     log(f"Publishing report directory {bc.report_dir} to {dest_dir}")
                     copything(bc.report_dir, dest_dir)

--- a/test/test_nightlies.py
+++ b/test/test_nightlies.py
@@ -239,8 +239,8 @@ class TestNightlyRunnerHarness(unittest.TestCase):
         self.assertEqual(
             info["files"],
             [
-                {"stored_path": "index.html", "gzip": False},
-                {"stored_path": "nightly_info.json", "gzip": False},
+                {"path": "index.html", "gzip": False},
+                {"path": "nightly_info.json", "gzip": False},
             ],
         )
         # Published reports should be moved out of the worktree so later runs start clean.
@@ -267,9 +267,9 @@ class TestNightlyRunnerHarness(unittest.TestCase):
         self.assertEqual(
             info["files"],
             [
-                {"stored_path": "index.html", "gzip": False},
-                {"stored_path": "nightly_info.json", "gzip": False},
-                {"stored_path": "results.json.gz", "gzip": True},
+                {"path": "index.html", "gzip": False},
+                {"path": "nightly_info.json", "gzip": False},
+                {"path": "results.json.gz", "gzip": True},
             ],
         )
 

--- a/test/test_nightlies.py
+++ b/test/test_nightlies.py
@@ -236,8 +236,42 @@ class TestNightlyRunnerHarness(unittest.TestCase):
             "https://nightlies.example/logs/publish-report.log",
         )
         self.assertIsNone(info["image_url"])
+        self.assertEqual(
+            info["files"],
+            [
+                {"stored_path": "index.html", "gzip": False},
+                {"stored_path": "nightly_info.json", "gzip": False},
+            ],
+        )
         # Published reports should be moved out of the worktree so later runs start clean.
         self.assertFalse((self.repos_dir / "testrepo" / "main" / "report").exists())
+
+    def test_runner_records_gzipped_files_in_nightly_info(self) -> None:
+        self.makefile(
+            "add gzipped report-producing nightly target",
+            [
+                "printf '<h1>ok</h1>\\n' > report/index.html",
+                "printf '{\"ok\":true}\\n' > report/results.json",
+            ],
+        )
+        self.git(["push", "origin", "main"], repo=self.work_dir)
+
+        self.nightly(
+            repo_updates={"branches": "main", "report": "report", "gzip": "*.json"},
+            complete=True,
+        )
+        result = self.run_runner("main", "publish-gzip-report.log")
+        report_dir = self.published_report(result)
+        info = json.loads((report_dir / "nightly_info.json").read_text())
+
+        self.assertEqual(
+            info["files"],
+            [
+                {"stored_path": "index.html", "gzip": False},
+                {"stored_path": "nightly_info.json", "gzip": False},
+                {"stored_path": "results.json.gz", "gzip": True},
+            ],
+        )
 
     def test_runner_handles_invalid_report_destination(self) -> None:
         invalid_reports = self.tmpdir / "reports-file"

--- a/views/docs.view
+++ b/views/docs.view
@@ -241,4 +241,13 @@ names.</dd>
 <dt><code>image_url</code></dt>
 <dd>The absolute URL to the configured report image when one exists,
 otherwise <code>null</code>.</dd>
+
+<dt><code>files</code></dt>
+<dd>A list of file records describing the published report contents.
+Each record contains <code>path</code>, the path actually stored
+under the report directory, and <code>gzip</code>, which is
+<code>true</code> when the runner created that stored file by gzipping a
+report artifact before upload. Downloaders can fetch
+<code>path</code> directly and, when <code>gzip</code> is true,
+ungzip it after download.</dd>
 </dl>


### PR DESCRIPTION
This PR adds a  a `files` inventory for each published report's `nightly_info.json`. Each entry records the stored path and whether the file was gzipped during publish. Long term this should make it easy to download a report.