### PR TITLE
Add `/exec` endpoint for report executables

### DIFF
--- a/server.py
+++ b/server.py
@@ -210,11 +210,12 @@ def robots_txt():
     return bottle.static_file("robots.txt", root='static/')
 
 
-@bottle.post("/exec/<report>/<filepath:path>")
-def exec_report_file(report: str, filepath: str):
+@bottle.post("/exec/<repo>/<run>/<filepath:path>")
+def exec_report_file(repo: str, run: str, filepath: str):
     args = bottle.request.forms.getall("arg")
     runner = nightlies.NightlyRunner(CONF_FILE)
     runner.load()
+    report = f"{repo}/{run}"
     report_dir, target = resolve_report_exec(runner.report_dir, report, filepath)
     bottle.response.content_type = "text/html; charset=UTF-8"
     return run_report_exec(report_dir, target, args)

--- a/server.py
+++ b/server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from typing import Optional
+from typing import Optional, Sequence
 from dataclasses import dataclass
 import bottle
 from pathlib import Path
@@ -34,6 +34,59 @@ class NightlyJob:
     log: str
     last_print: Optional[float] = None
     elapsed: Optional[float] = None
+
+
+def validate_relative_path(root: Path, path: Path, *, what: str) -> Path:
+    """
+    Returns the absolute path to `path` if it is a child of `root`; otherwise,
+    raises HTTP Error 400 with the message "Invalid {`what`}".
+    """
+    resolved = path.resolve()
+    try:
+        resolved.relative_to(root.resolve())
+    except ValueError:
+        raise bottle.HTTPError(400, f"Invalid {what}")
+    return resolved
+
+
+def resolve_report_exec(reports_dir: Path, report: str, filepath: str) -> tuple[Path, Path]:
+    """
+    Returns (`reports_dir`/`report`, `reports_dir`/`report`/`filepath`) as
+    absolute paths. If any component is not a child of the previous component,
+    raises HTTP error 400. If any component of `reports_dir`/`report`/`filepath`
+    doesn't exist, raises HTTP error 404.
+    """
+    report_dir = validate_relative_path(reports_dir, reports_dir / report, what="report")
+    if not report_dir.is_dir():
+        raise bottle.HTTPError(404, f"Unknown report {report}")
+
+    target = validate_relative_path(report_dir, report_dir / filepath, what="filepath")
+    if not target.is_file():
+        raise bottle.HTTPError(404, f"Missing executable {filepath}")
+
+    return report_dir, target
+
+
+def run_report_exec(report_dir: Path, target: Path, args: Sequence[str]) -> str:
+    """
+    Runs the file `target` with cwd set to `report_dir`. Passes `args`.  Raises
+    HTTP error 500 if the command returns status code != 0 or if
+    `subprocess.run(...)` fails with `OSError`.
+    """
+    try:
+        result = subprocess.run(
+            [str(target), *args],
+            cwd=report_dir,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as e:
+        raise bottle.HTTPError(500, str(e))
+
+    if result.returncode != 0:
+        message = f"Command exited with status {result.returncode}:\n{result.stderr or result.stdout}"
+        raise bottle.HTTPError(500, message)
+    return result.stdout
 
 def get_nightly_jobs(log_dir: Path) -> list[NightlyJob]:
     """Query slurm for running nightly jobs."""
@@ -155,6 +208,16 @@ def server_static(filepath):
 @bottle.route("/robots.txt")
 def robots_txt():
     return bottle.static_file("robots.txt", root='static/')
+
+
+@bottle.post("/exec/<report>/<filepath:path>")
+def exec_report_file(report: str, filepath: str):
+    args = bottle.request.forms.getall("arg")
+    runner = nightlies.NightlyRunner(CONF_FILE)
+    runner.load()
+    report_dir, target = resolve_report_exec(runner.report_dir, report, filepath)
+    bottle.response.content_type = "text/html; charset=UTF-8"
+    return run_report_exec(report_dir, target, args)
 
 @bottle.route("/dryrun", ["GET", "POST"])
 def dryrun():

--- a/test/test_nightlies.py
+++ b/test/test_nightlies.py
@@ -20,6 +20,7 @@ if str(ROOT) not in sys.path:
 
 from nightlies import NightlyRunner
 import apt
+import server
 
 
 class FakeRunner:
@@ -557,6 +558,70 @@ class TestNightlyRunnerHarness(unittest.TestCase):
                 f"stdout:\n{result.stdout}\n"
                 f"stderr:\n{result.stderr}"
             )
+
+
+class TestReportExec(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmpdir = Path(tempfile.mkdtemp(prefix="nr-server-"))
+        self.reports_dir = self.tmpdir / "reports"
+        self.logs_dir = self.tmpdir / "logs"
+        self.repos_dir = self.tmpdir / "repos"
+        self.config_file = self.tmpdir / "nightlies.conf"
+        self.reports_dir.mkdir()
+        self.logs_dir.mkdir()
+        self.repos_dir.mkdir()
+
+        self.report = "testrepo/1776156991:main:dee549aa"
+        self.report_dir = self.reports_dir / self.report
+        self.report_dir.mkdir(parents=True)
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmpdir)
+
+    def write_executable(self, relpath: str, script: str):
+        executable = self.report_dir / relpath
+        executable.parent.mkdir(parents=True, exist_ok=True)
+        executable.write_text(script)
+        executable.chmod(0o755)
+
+    def test_resolve_report_exec_rejects_path_traversal(self) -> None:
+        with self.assertRaises(server.bottle.HTTPError) as exc:
+            server.resolve_report_exec(self.reports_dir, self.report, "../outside")
+        self.assertEqual(exc.exception.status_code, 400)
+
+    def test_resolve_report_exec_rejects_missing_file(self) -> None:
+        with self.assertRaises(server.bottle.HTTPError) as exc:
+            server.resolve_report_exec(self.reports_dir, self.report, "missing-tool")
+        self.assertEqual(exc.exception.status_code, 404)
+        self.assertIn("Missing executable", exc.exception.body)
+
+    def test_run_report_exec_returns_stdout(self) -> None:
+        self.write_executable(
+            "bin/report-tool",
+            "#!/bin/sh\n"
+            "printf 'cwd=%s\\n' \"$PWD\"\n"
+            "printf 'args=%s,%s\\n' \"$1\" \"$2\"\n",
+        )
+        report, executable = server.resolve_report_exec(self.reports_dir, self.report, "bin/report-tool")
+        output = server.run_report_exec(report, executable, ["left", "right"])
+        self.assertEqual(
+            output,
+            f"cwd={self.report_dir.resolve()}\nargs=left,right\n",
+        )
+
+    def test_run_report_exec_returns_500_on_nonzero_exit(self) -> None:
+        self.write_executable(
+            "bin/report-tool-fail",
+            "#!/bin/sh\n"
+            "echo 'boom' >&2\n"
+            "exit 2\n",
+        )
+        report, executable = server.resolve_report_exec(self.reports_dir, self.report, "bin/report-tool-fail")
+        with self.assertRaises(server.bottle.HTTPError) as exc:
+            server.run_report_exec(self.report_dir.resolve(), executable, ["left", "right"])
+        self.assertEqual(exc.exception.status_code, 500)
+        self.assertIn("status 2", exc.exception.body)
+        self.assertIn("boom", exc.exception.body)
 
 
 if __name__ == "__main__":

--- a/test/test_nightlies.py
+++ b/test/test_nightlies.py
@@ -618,7 +618,7 @@ class TestReportExec(unittest.TestCase):
         )
         report, executable = server.resolve_report_exec(self.reports_dir, self.report, "bin/report-tool-fail")
         with self.assertRaises(server.bottle.HTTPError) as exc:
-            server.run_report_exec(self.report_dir.resolve(), executable, ["left", "right"])
+            server.run_report_exec(report, executable, ["left", "right"])
         self.assertEqual(exc.exception.status_code, 500)
         self.assertIn("status 2", exc.exception.body)
         self.assertIn("boom", exc.exception.body)

--- a/views/docs.view
+++ b/views/docs.view
@@ -251,3 +251,28 @@ report artifact before upload. Downloaders can fetch
 <code>path</code> directly and, when <code>gzip</code> is true,
 ungzip it after download.</dd>
 </dl>
+
+<h2>Server-side report tools</h2>
+
+<p>Published reports can include executables or scripts and invoke them
+through the nightly server with a POST request to:</p>
+
+<pre>/exec/&lt;repo&gt;/&lt;run&gt;/&lt;filepath&gt;</pre>
+
+<p>Here <code>repo</code> is the short repository name,
+<code>run</code> is a published run directory name like
+<code>1776156991:main:dee549aa</code>, and <code>filepath</code> is a
+path inside that report directory. The server rejects requests that try
+to escape the chosen report directory.</p>
+
+<p>The server executes the requested file synchronously with its current
+working directory set to the published report directory. On success, the
+server returns the tool's standard output as the HTTP response. If the
+tool exits with a non-zero status, the server returns an error using the
+tool's standard error output when available.</p>
+
+<p>Report pages can pass arguments by posting repeated
+<code>arg</code> form fields. For example, a report can submit
+<code>old_run</code> and <code>new_run</code> indirectly by placing them
+in hidden inputs named <code>arg</code> and then interpreting positional
+arguments inside the tool.</p>


### PR DESCRIPTION
Add an `/exec` endpoint so that reports can run local executables synchronously. The motivating use case for this is to be able to write a diff tool that renders on the server. It could be used for anything, though.

The path format is `/exec/<repo>/<timestamp>:<branch>:<commit>/<file>?arg=<arg1>&arg=<arg2>...`. `<repo>/<timestamp>:<branch>:<commit>` specifies the report to use and mirrors the `reports` "endpoint". `<file>` is the file within the report directory to execute. `arg`s specify the arguments to pass to the executable.

When this endpoint is requested, the server will run the executable synchronously, then respond with the stdout.
