### PR TITLE
Reject overlapping dryrun sync requests

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -13,6 +13,8 @@ jobs:
         python-version: "3.12"
     - uses: astral-sh/setup-uv@v5
       with:
-        cache-dependency-glob: ".github/workflows/mypy.yml,setup.cfg"
+        cache-dependency-glob: |
+          .github/workflows/mypy.yml
+          setup.cfg
     - run: uv run test/test_nightlies.py
     - run: uv run --with mypy mypy

--- a/server.py
+++ b/server.py
@@ -156,10 +156,20 @@ def server_static(filepath):
 def robots_txt():
     return bottle.static_file("robots.txt", root='static/')
 
+def reject_if_sync_running(runner: nightlies.NightlyRunner) -> None:
+    runner.load_pid()
+    if runner.data and "pid" in runner.data:
+        try:
+            os.kill(runner.data["pid"], 0)
+        except OSError:
+            return
+        raise bottle.HTTPError(409, "Nightly sync already running")
+
 @bottle.route("/dryrun", ["GET", "POST"])
 def dryrun():
     runner = nightlies.NightlyRunner(CONF_FILE)
     runner.load()
+    reject_if_sync_running(runner)
     runner.config["DEFAULT"]["dryrun"] = "true"
     run_nightlies(runner.config)
     bottle.redirect("/")
@@ -173,16 +183,11 @@ def fullrun():
 def runnow():
     repo = bottle.request.forms.get('repo')
     branch = bottle.request.forms.get('branch')
+    assert repo is not None
+    assert branch is not None
     runner = nightlies.NightlyRunner(CONF_FILE)
     runner.load()
-    runner.load_pid()
-    if runner.data and "pid" in runner.data:
-        try:
-            os.kill(runner.data["pid"], 0)
-        except OSError:
-            pass
-        else:
-            raise bottle.HTTPError(409, "Nightly sync already running")
+    reject_if_sync_running(runner)
     for r in runner.repos:
         if r.name == repo:
             r.read()
@@ -205,6 +210,8 @@ def runnow():
 def rmbranch():
     repo_name = bottle.request.forms.get('repo')
     branch = bottle.request.forms.get('branch')
+    assert repo_name is not None
+    assert branch is not None
     runner = nightlies.NightlyRunner(CONF_FILE)
     runner.load()
     for repo in runner.repos:

--- a/test/test_nightlies.py
+++ b/test/test_nightlies.py
@@ -2,15 +2,16 @@
 
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
 import configparser
-import bottle
 import json
 import os
 import shutil
 import subprocess
 import sys
 import tempfile
+import types
 import unittest
 from unittest import mock
 
@@ -21,7 +22,6 @@ if str(ROOT) not in sys.path:
 
 from nightlies import NightlyRunner
 import apt
-import server
 
 
 class FakeRunner:
@@ -424,13 +424,41 @@ class TestNightlyRunnerHarness(unittest.TestCase):
             )
         )
 
-        with (
-            mock.patch.object(server, "CONF_FILE", str(self.config_file)),
-            mock.patch.object(server, "run_nightlies") as run_nightlies,
-            mock.patch.object(bottle, "redirect") as redirect,
-        ):
-            with self.assertRaises(bottle.HTTPError) as ctx:
-                server.dryrun()
+        bottle = types.ModuleType("bottle")
+
+        class HTTPError(Exception):
+            def __init__(self, status_code: int, body: str = "") -> None:
+                super().__init__(body)
+                self.status_code = status_code
+                self.body = body
+
+        def decorator(*_args: object, **_kwargs: object) -> object:
+            return lambda fn: fn
+
+        bottle.HTTPError = HTTPError
+        bottle.route = decorator
+        bottle.post = decorator
+        bottle.view = decorator
+        bottle.static_file = lambda *_args, **_kwargs: None
+        bottle.redirect = lambda _url: None
+        bottle.run = lambda *_args, **_kwargs: None
+
+        status = types.ModuleType("status")
+        status.system_state_html = lambda: ""
+
+        with mock.patch.dict(sys.modules, {"bottle": bottle, "status": status}):
+            sys.modules.pop("server", None)
+            server = importlib.import_module("server")
+            try:
+                with (
+                    mock.patch.object(server, "CONF_FILE", str(self.config_file)),
+                    mock.patch.object(server, "run_nightlies") as run_nightlies,
+                    mock.patch.object(bottle, "redirect") as redirect,
+                ):
+                    with self.assertRaises(HTTPError) as ctx:
+                        server.dryrun()
+            finally:
+                sys.modules.pop("server", None)
 
         self.assertEqual(ctx.exception.status_code, 409)
         self.assertEqual(ctx.exception.body, "Nightly sync already running")

--- a/test/test_nightlies.py
+++ b/test/test_nightlies.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import configparser
+import bottle
 import json
 import os
 import shutil
@@ -20,6 +21,7 @@ if str(ROOT) not in sys.path:
 
 from nightlies import NightlyRunner
 import apt
+import server
 
 
 class FakeRunner:
@@ -408,6 +410,32 @@ class TestNightlyRunnerHarness(unittest.TestCase):
         contents = metadata.read_text()
         self.assertIn('"commit"', contents)
         self.assertIn('"time"', contents)
+
+    def test_dryrun_rejects_when_sync_is_running(self) -> None:
+        self.write_config(repo_updates={})
+        self.pid_file.write_text(
+            json.dumps(
+                {
+                    "pid": os.getpid(),
+                    "start": "2026-04-21T15:00:00",
+                    "config": str(self.config_file),
+                    "log": str(self.logs_dir / "running.log"),
+                }
+            )
+        )
+
+        with (
+            mock.patch.object(server, "CONF_FILE", str(self.config_file)),
+            mock.patch.object(server, "run_nightlies") as run_nightlies,
+            mock.patch.object(bottle, "redirect") as redirect,
+        ):
+            with self.assertRaises(bottle.HTTPError) as ctx:
+                server.dryrun()
+
+        self.assertEqual(ctx.exception.status_code, 409)
+        self.assertEqual(ctx.exception.body, "Nightly sync already running")
+        run_nightlies.assert_not_called()
+        redirect.assert_not_called()
 
     def test_load_normalizes_baseurl_with_trailing_slash(self) -> None:
         self.write_config(repo_updates={}, default_updates={"baseurl": "https://nightlies.example"})


### PR DESCRIPTION
Reject `/dryrun` requests with `409` when a nightly sync is already running. This makes `/dryrun` safe for agent use.