### PR TITLE
Add a CLI command to open published reports

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -21,6 +21,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+import webbrowser
 
 
 ## Setup & config file
@@ -497,12 +498,12 @@ def fetch_published_report(
     client_config: ClientConfig,
     repo: str,
     entry: LogEntry,
-) -> tuple[str, Manifest]:
+) -> str:
     log_text = client_config.fetch(entry.url)
     report_url = find_report_url_in_log(repo, log_text)
     if report_url is None:
         raise CliError("No published report found in log.")
-    return report_url, fetch_manifest(client_config, report_url)
+    return report_url
 
 
 def fetch_manifest(client_config: ClientConfig, report_url: str) -> Manifest:
@@ -713,7 +714,8 @@ def cmd_download(client_config: ClientConfig, repo: str, selector: RunSelector) 
     if run_log is None:
         raise CliError("No matching log found.")
 
-    report_url, manifest = fetch_published_report(client_config, repo, run_log.entry)
+    report_url = fetch_published_report(client_config, repo, run_log.entry)
+    manifest = fetch_manifest(client_config, report_url)
     output_dir = Path(urllib.parse.urlsplit(report_url).path.rstrip("/")).name
     file_count = download_report_files(report_url, manifest.files, Path(output_dir), client_config)
     print(f"Downloaded {file_count} files to {output_dir}/")
@@ -752,8 +754,19 @@ def cmd_status(client_config: ClientConfig, repo: str, selector: RunSelector) ->
     run_log = next(matching_run_logs(iter_entries(client_config), repo, selector), None)
     if run_log is None:
         raise CliError("No matching log found.")
-    _, manifest = fetch_published_report(client_config, repo, run_log.entry)
+    report_url = fetch_published_report(client_config, repo, run_log.entry)
+    manifest = fetch_manifest(client_config, report_url)
     print(manifest.text())
+    return 0
+
+
+def cmd_open(client_config: ClientConfig, repo: str, selector: RunSelector) -> int:
+    run_log = next(matching_run_logs(iter_entries(client_config), repo, selector), None)
+    if run_log is None:
+        raise CliError("No matching log found.")
+    url = urllib.parse.urljoin(client_config.index_url, fetch_published_report(client_config, repo, run_log.entry))
+    if not webbrowser.open_new(url):
+        raise CliError(f"could not open browser for {url}")
     return 0
 
 
@@ -799,6 +812,9 @@ def build_parser() -> argparse.ArgumentParser:
 
     download_parser = subparsers.add_parser("download", help="Download a published report for a repo branch run.")
     add_run_selector_args(download_parser)
+
+    open_parser = subparsers.add_parser("open", help="Open a published report for a repo branch run in a browser.")
+    add_run_selector_args(open_parser)
     return parser
 
 
@@ -812,7 +828,7 @@ def main(argv: list[str] | None = None) -> int:
         if args.command == "sync":
             return cmd_sync(client_config)
         repo = infer_repo(".")
-        if args.command in {"log", "start", "status"} and args.branch is None:
+        if args.command in {"log", "start", "status", "open"} and args.branch is None:
             args.branch = current_branch(".")
         if args.command == "start":
             return cmd_start(client_config, repo, args.branch)
@@ -825,6 +841,8 @@ def main(argv: list[str] | None = None) -> int:
             return cmd_status(client_config, repo, selector)
         if args.command == "download":
             return cmd_download(client_config, repo, selector)
+        if args.command == "open":
+            return cmd_open(client_config, repo, selector)
         raise CliError(f"unknown command {args.command}")
     except (MissingClientConfig, InvalidClientConfig) as exc:
         print(f"error: {exc}. Run `cli setup <url>` to fix.", file=sys.stderr)

--- a/test/test_nightlies.py
+++ b/test/test_nightlies.py
@@ -475,6 +475,67 @@ class TestCli(unittest.TestCase):
                     cli.RunSelector(args.branch, args.date, args.time),
                 )
 
+    def test_cmd_open_opens_published_report(self) -> None:
+        report_name = "1713625200:taylor-order0:deadbeef"
+        client_config = self.client_config()
+        report_url = self.report_url(client_config, "herbie/" + report_name)
+        entry = cli.LogEntry(
+            name="2026-04-20-150000-1-herbie-taylor-order0.log",
+            url="/logs/taylor-order0.log",
+        )
+        opener = FakeOpener(
+            {
+                self.absolute_url(client_config, entry.url): (
+                    "Publishing report directory /tmp/report to "
+                    f"/srv/reports/herbie/{report_name}\n"
+                ).encode("utf-8"),
+            }
+        )
+
+        with (
+            self.client_open_patch(opener),
+            mock.patch.object(cli, "iter_entries", return_value=iter([entry])),
+            mock.patch.object(cli.webbrowser, "open_new", return_value=True) as open_new,
+        ):
+            rc = cli.cmd_open(
+                client_config,
+                "herbie",
+                cli.RunSelector("taylor-order0", "2026-04-20", "15:00:00"),
+            )
+
+        self.assertEqual(rc, 0)
+        open_new.assert_called_once_with(report_url)
+
+    def test_main_open_without_branch_defaults_to_current_branch(self) -> None:
+        report_name = "1713570003:feature:decafbad"
+        client_config = self.client_config()
+        report_url = self.report_url(client_config, "herbie/" + report_name)
+        entry = cli.LogEntry(
+            name="2026-04-21-150000-1-herbie-feature.log",
+            url="/logs/feature.log",
+        )
+        opener = FakeOpener(
+            {
+                self.absolute_url(client_config, entry.url): (
+                    "Publishing report directory /tmp/report to "
+                    f"/srv/reports/herbie/{report_name}\n"
+                ).encode("utf-8"),
+            }
+        )
+
+        with (
+            self.client_open_patch(opener),
+            mock.patch.object(cli, "load_client_config", return_value=client_config),
+            mock.patch.object(cli, "infer_repo", return_value="herbie"),
+            mock.patch.object(cli, "current_branch", return_value="feature"),
+            mock.patch.object(cli, "iter_entries", return_value=iter([entry])),
+            mock.patch.object(cli.webbrowser, "open_new", return_value=True) as open_new,
+        ):
+            rc = cli.main(["open"])
+
+        self.assertEqual(rc, 0)
+        open_new.assert_called_once_with(report_url)
+
 
     def test_cmd_setup_saves_client_config(self) -> None:
         state = cli.IndexState(False, [cli.StartTarget("herbie", "main", False)])


### PR DESCRIPTION
This PR adds `cli.py open <branch> <date> <time>` so a published nightly report can be opened directly in a browser window. The command also follows the existing current-branch defaulting behavior when `branch` is omitted.