### PR TITLE
Send slack message on git failure

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -144,6 +144,7 @@ def run_branch(bc: config.BranchConfig, log_name: str) -> int:
     info: Dict[str, str] = {}
     slack_output = slack.make_output(bc.config.secrets, bc.slack_spec, bc.repo_name)
     start: Optional[datetime] = None
+    out: Optional[str] = None
 
     if bc.base_url:
         import urllib.parse
@@ -164,19 +165,19 @@ def run_branch(bc: config.BranchConfig, log_name: str) -> int:
 
     signal.signal(signal.SIGTERM, handle_sigterm)
 
-    run(["git", "-C", bc.branch_dir, "reset", "--hard", f"origin/{bc.branch_name}"], check=True)
-    run(["git", "-C", bc.branch_dir, "submodule", "update", "--init", "--recursive", "--force"], check=True)
-
-    out = run(
-        ["git", "-C", bc.branch_dir, "rev-parse", f"origin/{bc.branch_name}"],
-        capture_output=True, check=True
-    ).stdout.decode("ascii").strip()
-
-    start = datetime.now(timezone.utc)
     try:
+        run(["git", "-C", bc.branch_dir, "reset", "--hard", f"origin/{bc.branch_name}"], check=True)
+        run(["git", "-C", bc.branch_dir, "submodule", "update", "--init", "--recursive", "--force"], check=True)
+
+        out = run(
+            ["git", "-C", bc.branch_dir, "rev-parse", f"origin/{bc.branch_name}"],
+            capture_output=True, check=True
+        ).stdout.decode("ascii").strip()
+
+        start = datetime.now(timezone.utc)
         to = parse_time(bc.timeout)
         cmd = ["make", "-C", str(bc.branch_dir), "nightly"]
-        
+
         if bc.report_dir:
             if bc.report_dir.exists():
                 shutil.rmtree(bc.report_dir, ignore_errors=True)
@@ -195,66 +196,68 @@ def run_branch(bc: config.BranchConfig, log_name: str) -> int:
         log(f"Successfully ran on branch {bc.branch_name}")
         status = "success"
 
-    metadata = read_metadata(bc.metadata_file)
-    metadata["commit"] = out
-    metadata["time"] = time.time()
-    save_metadata(bc.metadata_file, metadata)
+    if start is not None:
+        assert out is not None
+        metadata = read_metadata(bc.metadata_file)
+        metadata["commit"] = out
+        metadata["time"] = time.time()
+        save_metadata(bc.metadata_file, metadata)
 
-    if bc.report_dir and bc.report_dir.exists():
-        try:
-            compressed: set[Path] = set()
-            if bc.gzip:
-                log(f"GZipping all {bc.gzip} files")
-                compressed = gzip_matching_files(bc.report_dir, shlex.split(bc.gzip))
+        if bc.report_dir and bc.report_dir.exists():
+            try:
+                compressed: set[Path] = set()
+                if bc.gzip:
+                    log(f"GZipping all {bc.gzip} files")
+                    compressed = gzip_matching_files(bc.report_dir, shlex.split(bc.gzip))
 
-            total, biggest, _ = tree_size(bc.report_dir)
-            if bc.warn_report and total > bc.warn_report:
-                msg = (
-                    f"Report size {format_size(total)} exceeds limit {format_size(bc.warn_report)}"
-                    f"; largest file `{biggest}`"
-                )
-                log(f"Report `{bc.branch_name}` is {format_size(total)}; largest file `{biggest}`")
+                total, biggest, _ = tree_size(bc.report_dir)
+                if bc.warn_report and total > bc.warn_report:
+                    msg = (
+                        f"Report size {format_size(total)} exceeds limit {format_size(bc.warn_report)}"
+                        f"; largest file `{biggest}`"
+                    )
+                    log(f"Report `{bc.branch_name}` is {format_size(total)}; largest file `{biggest}`")
+                    if slack_output:
+                        slack_output.warn("report-size", msg)
+
+                if "url" not in info and bc.base_url:
+                    name = f"{int(time.time())}:{bc.branch_filename}:{out[:8]}"
+                    dest_dir = bc.reports_dir / bc.repo_name / name
+                    report_url = bc.base_url + "reports/" + bc.repo_name + "/" + name
+
+                    if bc.report_dir.exists():
+                        image_url = None
+                        if bc.image_file and bc.image_file.exists():
+                            path = bc.image_file.relative_to(bc.report_dir)
+                            image_url = report_url + "/" + str(path)
+                        if status == "success":
+                            write_nightly_info(
+                                bc,
+                                commit=out,
+                                status=status,
+                                started_at=start,
+                                finished_at=datetime.now(timezone.utc),
+                                log=log_name,
+                                log_url=bc.base_url + "logs/" + urllib.parse.quote(log_name),
+                                report_url=report_url,
+                                image_url=image_url,
+                                compressed=compressed,
+                            )
+                        log(f"Publishing report directory {bc.report_dir} to {dest_dir}")
+                        copything(bc.report_dir, dest_dir)
+                        info["url"] = report_url
+                        if bc.image_file and bc.image_file.exists():
+                            log(f"Linking image file {bc.image_file}")
+                            assert image_url is not None
+                            info["img"] = image_url
+                        shutil.rmtree(bc.report_dir, ignore_errors=True)
+                    else:
+                        log(f"Report directory {bc.report_dir} does not exist")
+            except OSError as e:
+                msg = f"Error saving report: {e}"
+                log(f"Error saving report for `{bc.branch_name}`: {e}")
                 if slack_output:
-                    slack_output.warn("report-size", msg)
-
-            if "url" not in info and bc.base_url:
-                name = f"{int(time.time())}:{bc.branch_filename}:{out[:8]}"
-                dest_dir = bc.reports_dir / bc.repo_name / name
-                report_url = bc.base_url + "reports/" + bc.repo_name + "/" + name
-
-                if bc.report_dir.exists():
-                    image_url = None
-                    if bc.image_file and bc.image_file.exists():
-                        path = bc.image_file.relative_to(bc.report_dir)
-                        image_url = report_url + "/" + str(path)
-                    if status == "success":
-                        write_nightly_info(
-                            bc,
-                            commit=out,
-                            status=status,
-                            started_at=start,
-                            finished_at=datetime.now(timezone.utc),
-                            log=log_name,
-                            log_url=bc.base_url + "logs/" + urllib.parse.quote(log_name),
-                            report_url=report_url,
-                            image_url=image_url,
-                            compressed=compressed,
-                        )
-                    log(f"Publishing report directory {bc.report_dir} to {dest_dir}")
-                    copything(bc.report_dir, dest_dir)
-                    info["url"] = report_url
-                    if bc.image_file and bc.image_file.exists():
-                        log(f"Linking image file {bc.image_file}")
-                        assert image_url is not None
-                        info["img"] = image_url
-                    shutil.rmtree(bc.report_dir, ignore_errors=True)
-                else:
-                    log(f"Report directory {bc.report_dir} does not exist")
-        except OSError as e:
-            msg = f"Error saving report: {e}"
-            log(f"Error saving report for `{bc.branch_name}`: {e}")
-            if slack_output:
-                slack_output.warn("broken-report", msg)
+                    slack_output.warn("broken-report", msg)
 
     total, biggest, _ = tree_size(bc.branch_dir)
     if bc.warn_branch and total > bc.warn_branch:
@@ -277,7 +280,8 @@ def run_branch(bc: config.BranchConfig, log_name: str) -> int:
             slack_output.warn("log-size", msg)
 
     info["result"] = f"*{status}*" if status != "success" else "success"
-    info["time"] = format_time((datetime.now(timezone.utc) - start).total_seconds())
+    if start is not None:
+        info["time"] = format_time((datetime.now(timezone.utc) - start).total_seconds())
 
     if slack_output:
         log("Posting results of run to slack!")

--- a/test/test_nightlies.py
+++ b/test/test_nightlies.py
@@ -29,6 +29,7 @@ if str(ROOT) not in sys.path:
 from nightlies import NightlyRunner
 import apt
 import cli
+import runner
 
 
 class FakeRunner:
@@ -1420,6 +1421,43 @@ class TestServerRunNow(unittest.TestCase):
         self.assertEqual(ctx.exception.body, "Job nightly:testrepo:feature_2ftest already queued")
         repo_state.read.assert_called_once_with()
         run_nightlies.assert_not_called()
+
+
+class TestBranchRunner(unittest.TestCase):
+    def test_setup_failure_posts_to_slack(self) -> None:
+        slack_output = mock.Mock()
+        bc = SimpleNamespace(
+            config=SimpleNamespace(secrets=configparser.ConfigParser()),
+            slack_spec="workspace/channel",
+            repo_name="testrepo",
+            branch_name="main",
+            branch_dir=Path("/tmp/testrepo/main"),
+            base_url="https://nightly.example/",
+            warn_branch=None,
+            warn_log=None,
+            logs_dir=Path("/tmp"),
+        )
+
+        with (
+            mock.patch.object(runner.slack, "make_output", return_value=slack_output),
+            mock.patch.object(
+                runner,
+                "run",
+                side_effect=[
+                    subprocess.CompletedProcess(["git"], 0),
+                    subprocess.CalledProcessError(128, ["git", "submodule", "update"]),
+                ],
+            ),
+        ):
+            rc = runner.run_branch(cast(Any, bc), "setup-failure.log")
+
+        self.assertEqual(rc, 1)
+        slack_output.post.assert_called_once()
+        branch, info = slack_output.post.call_args.args
+        self.assertEqual(branch, "main")
+        self.assertEqual(info["result"], "*failure*")
+        self.assertEqual(info["logurl"], "https://nightly.example/logs/setup-failure.log")
+        self.assertNotIn("time", info)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Run git commands in the main try block of `run_branch` so that if there is an exception, it will be caught and slack will run normally.

This means that code in the try block and beyond can no longer
assume that variables `start` and `out` were initialized; nor
can it assume that the old report directory was cleaned and the
user's code was run. Add guards to reflect this.

`start is not None` was chosen to signify that git was
successful and the user's code started, because `slack.py:97`
checks the derived value `info['time']` to determine whether the user's code started.
