### PR TITLE
Explain missing branch and allow status when no report is published

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -484,6 +484,7 @@ def tail_log(client_config: ClientConfig, url: str) -> None:
 
 ## Reports
 
+REPORT_PATH_CUTOFF = datetime.date(2025, 12, 28)
 PUBLISH_RE = re.compile(r"^Publishing report directory .* to .*/reports/([^/]+)/([^/\n]+)$", re.MULTILINE)
 
 
@@ -755,7 +756,15 @@ def cmd_status(client_config: ClientConfig, repo: str, selector: RunSelector) ->
     run_log = next(matching_run_logs(iter_entries(client_config), repo, selector), None)
     if run_log is None:
         raise CliError("No matching log found.")
-    _, manifest = fetch_published_report(client_config, repo, run_log.entry)
+    log_text = client_config.fetch(run_log.entry.url)
+    report_url = find_report_url_in_log(repo, log_text)
+    if report_url is None:
+        if datetime.date.fromisoformat(run_log.date) < REPORT_PATH_CUTOFF:
+            print("No report (run is too old). Run `uvx nightlies log` to view log details")
+        else:
+            print("No report. Run `uvx nightlies log` to view log details")
+        return 0
+    manifest = fetch_manifest(client_config, report_url)
     print(manifest.text())
     return 0
 

--- a/test/test_nightlies.py
+++ b/test/test_nightlies.py
@@ -456,7 +456,7 @@ class TestCli(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertIn("herbie / feature\n", stdout.getvalue())
 
-    def test_cmd_status_requires_published_report(self) -> None:
+    def test_cmd_status_allows_missing_report(self) -> None:
         entry = cli.LogEntry(
             name="2026-04-20-150000-1-herbie-taylor-order0.log",
             url="/logs/taylor-order0.log",
@@ -466,14 +466,42 @@ class TestCli(unittest.TestCase):
         with (
             self.client_open_patch(opener),
             mock.patch.object(cli, "iter_entries", return_value=iter([entry])),
+            mock.patch("sys.stdout", new_callable=io.StringIO) as stdout,
         ):
-            with self.assertRaisesRegex(cli.CliError, "No published report found in log."):
-                args = cli.build_parser().parse_args(["status", "taylor-order0", "2026-04-20", "150000"])
-                cli.cmd_status(
-                    self.client_config(),
-                    "herbie",
-                    cli.RunSelector(args.branch, args.date, args.time),
-                )
+            args = cli.build_parser().parse_args(["status", "taylor-order0", "2026-04-20", "150000"])
+            rc = cli.cmd_status(
+                self.client_config(),
+                "herbie",
+                cli.RunSelector(args.branch, args.date, args.time),
+            )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(stdout.getvalue(), "No report. Run `uvx nightlies log` to view log details\n")
+
+    def test_cmd_status_explains_old_missing_report(self) -> None:
+        entry = cli.LogEntry(
+            name="2025-08-30-030107-1-herbie-main.log",
+            url="/logs/main.log",
+        )
+        opener = FakeOpener({self.absolute_url(self.client_config(), entry.url): b"old log\n"})
+
+        with (
+            self.client_open_patch(opener),
+            mock.patch.object(cli, "iter_entries", return_value=iter([entry])),
+            mock.patch("sys.stdout", new_callable=io.StringIO) as stdout,
+        ):
+            args = cli.build_parser().parse_args(["status", "main", "2025-08-30", "030107"])
+            rc = cli.cmd_status(
+                self.client_config(),
+                "herbie",
+                cli.RunSelector(args.branch, args.date, args.time),
+            )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(
+            stdout.getvalue(),
+            "No report (run is too old). Run `uvx nightlies log` to view log details\n",
+        )
 
 
     def test_cmd_setup_saves_client_config(self) -> None:


### PR DESCRIPTION
This PR is for agents, it makes `nightlies start` explain that when a branch is missing it might be because it's new and you need to `nightlies sync`.