### PR TITLE
Allow partial date filters in run listing

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -420,7 +420,7 @@ def matching_run_logs(
             continue
         if selector.branch is not None and run.branch != selector.branch:
             continue
-        if selector.date is not None and run.date != selector.date:
+        if selector.date is not None and not run.date.startswith(selector.date):
             continue
         if selector.time is not None and run.time != selector.time:
             continue
@@ -773,7 +773,12 @@ def normalize_time(value: str | None) -> str | None:
 
 def add_run_selector_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("branch", nargs="?", default=None, help="Branch name.")
-    parser.add_argument("date", nargs="?", default=None, help="Run date as YYYY-MM-DD.")
+    parser.add_argument(
+        "date",
+        nargs="?",
+        default=None,
+        help="Run date as YYYY, YYYY-MM, or YYYY-MM-DD.",
+    )
     parser.add_argument("time", nargs="?", default=None, type=normalize_time, help="Run time as HH:MM:SS or HHMMSS.")
 
 

--- a/test/test_nightlies.py
+++ b/test/test_nightlies.py
@@ -303,6 +303,42 @@ class TestCli(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertEqual(stdout.getvalue(), "2026-04-20 09:08:32 taylor-order0\n")
 
+    def test_cmd_list_accepts_partial_date_filters(self) -> None:
+        entries = [
+            cli.LogEntry(
+                name="2026-08-19-123456-1-herbie-taylor-order0.log",
+                url="/logs/august.log",
+            ),
+            cli.LogEntry(
+                name="2026-09-20-123456-1-herbie-taylor-order0.log",
+                url="/logs/september.log",
+            ),
+            cli.LogEntry(
+                name="2027-08-21-123456-1-herbie-taylor-order0.log",
+                url="/logs/next-year.log",
+            ),
+        ]
+
+        with mock.patch.object(
+            cli,
+            "iter_entries",
+            side_effect=lambda _client_config: iter(reversed(entries)),
+        ):
+            for date, expected in (
+                ("2026", "2026-08-19 12:34:56 taylor-order0\n2026-09-20 12:34:56 taylor-order0\n"),
+                ("2026-08", "2026-08-19 12:34:56 taylor-order0\n"),
+            ):
+                with mock.patch("sys.stdout", new_callable=io.StringIO) as stdout:
+                    args = cli.build_parser().parse_args(["list", "taylor-order0", date])
+                    rc = cli.cmd_list(
+                        self.client_config(),
+                        "herbie",
+                        cli.RunSelector(args.branch, args.date, args.time),
+                    )
+
+                self.assertEqual(rc, 0)
+                self.assertEqual(stdout.getvalue(), expected)
+
     def test_cmd_list_branch_lists_all_matching_runs(self) -> None:
         entries = [
             cli.LogEntry(


### PR DESCRIPTION
This PR makes the CLI a little more usable for finding a report at around some date.